### PR TITLE
Added Building a unique docker image using commit hash to the Jenkins file

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -194,6 +194,22 @@ pipeline {
       }
     }
 
+    stage('Build & Push Docker Image') {
+      when {
+          branch 'main'
+      }
+      steps {
+          script {
+              // Building a unique Docker image using the commit hash
+              def dockerImage = "charbel123456/ensf400-finalproject:${GIT_COMMIT}"
+              echo "Building Docker image: ${dockerImage}"
+              sh "docker build -t ${dockerImage} ."
+              echo "Pushing Docker image to registry..."
+              sh "docker push ${dockerImage}"
+          }
+      }
+    }
+
 
     // This is the stage where we deploy to production.  If any test
     // fails, we won't get here.  Note that we aren't really doing anything - this


### PR DESCRIPTION
For every commit, the Docker image is tagged with that specific commit hash—creating a uniquely identifiable image for each update. This helps with traceability, so you can always tell which version of your code is deployed.